### PR TITLE
fix: Fix Margin of Context Menu Being Too Big

### DIFF
--- a/src/gui/chat_bubble.py
+++ b/src/gui/chat_bubble.py
@@ -84,14 +84,14 @@ class ChatBubble(QHBoxLayout):
             sender_icon.clicked.connect(self.on_icon_clicked)
 
             if self.sender_id == "You":
-                bubble.setStyleSheet("margin: 0px 0px 0px 100px;")
+                bubble.setStyleSheet("QFrame { padding: 0px 0px 0px 100px;}")
                 bottom_layout.addStretch(1)
                 bottom_layout.addWidget(self.play_button)
                 bubble_layout.addLayout(bottom_layout)
                 self.addWidget(bubble)
                 self.addWidget(sender_icon, alignment=Qt.AlignVCenter)
             else:
-                bubble.setStyleSheet("margin: 0px 100px 0px 0px;")
+                bubble.setStyleSheet("QFrame { padding: 0px 100px 0px 0px;}")
                 bottom_layout.addWidget(self.play_button)
                 bottom_layout.addStretch(1)
                 bubble_layout.addLayout(bottom_layout)
@@ -102,11 +102,11 @@ class ChatBubble(QHBoxLayout):
             sender_icon.clicked.connect(self.on_icon_clicked)
 
             if self.sender_id == "You":
-                bubble.setStyleSheet("margin: 0px 0px 0px 100px;")
+                bubble.setStyleSheet("QFrame { padding: 0px 0px 0px 100px; }")
                 self.addWidget(bubble)
                 self.addWidget(sender_icon, alignment=Qt.AlignVCenter)
             else:
-                bubble.setStyleSheet("margin: 0px 100px 0px 0px;")
+                bubble.setStyleSheet("QFrame { padding: 0px 100px 0px 0px; }")
                 self.addWidget(sender_icon, alignment=Qt.AlignVCenter)
                 self.addWidget(bubble)
 


### PR DESCRIPTION
close #44 
スタイルを入れるところは詳しくなくて、右クリックメニューにも反映してしまった。QFrameだけと指定したら解決した。